### PR TITLE
os/board/rtl8730e: fix wifi events for bridge

### DIFF
--- a/os/board/rtl8730e/src/component/os/tizenrt/rtk_wifi_utils.h
+++ b/os/board/rtl8730e/src/component/os/tizenrt/rtk_wifi_utils.h
@@ -64,7 +64,6 @@ typedef enum WiFi_InterFace_ID {
 	RTK_WIFI_STATION_IF,			// Station mode (turns on wpa_supplicant)
 	RTK_WIFI_SOFT_AP_IF,			// Soft AP mode (turns on hostapd)
 	RTK_WIFI_P2P_IF,					// P2P mode (turns on wpa_supplicant)
-  RTK_WIFI_AP_STA_IF
 } WiFi_InterFace_ID_t;
 
 typedef struct rtk_reason {
@@ -73,6 +72,7 @@ typedef struct rtk_reason {
 	int8_t ssid_len;					// length of ssid - # of valid octets
 	uint8_t ssid[33];	// 802.11 spec defined up to 32 octets of data
 	char bssid[17];	// BSS identification, char string e.g. xx:xx:xx:xx:xx:xx
+	WiFi_InterFace_ID_t if_id; // In which interface the reason was set
 } rtk_reason_t;
 
 /**

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
@@ -131,11 +131,12 @@ static void wifi_disconn_hdl(char *buf, int buf_len, int flags, void *userdata)
 		key_mgmt = *(u32*)(buf+8);
 	}
 #if defined(CONFIG_PLATFORM_TIZENRT_OS)
-	rtk_reason_t dummy_reason;
-	memset(&dummy_reason, 0, sizeof(rtk_reason_t));
+	rtk_reason_t reason;
+	memset(&reason, 0, sizeof(rtk_reason_t));
+	reason.if_id = RTK_WIFI_STATION_IF;
 	if (g_link_down) {
 		nvdbg("RTK_API rtk_handle_disconnect send link_down\n");
-		g_link_down(&dummy_reason);
+		g_link_down(&reason);
 	}
 	wifi_unreg_event_handler(WIFI_EVENT_DISCONNECT, wifi_disconn_hdl);
 #endif
@@ -237,6 +238,7 @@ int wifi_connect(rtw_network_info_t *connect_param, unsigned char block)
 
 #if defined(CONFIG_PLATFORM_TIZENRT_OS)
 			memset(&reason, 0, sizeof(rtk_reason_t));
+			reason.if_id = RTK_WIFI_STATION_IF;
 			reason.reason_code = RTK_STATUS_SUCCESS;
 
 			if (g_link_up) {
@@ -362,6 +364,7 @@ static void wifi_ap_sta_assoc_hdl( char* buf, int buf_len, int flags, void* user
 	//USER TODO
 	rtk_reason_t reason;
 	memset(&reason, 0, sizeof(rtk_reason_t));
+	reason.if_id = RTK_WIFI_SOFT_AP_IF;
 	if (strlen(buf) >= 17) {			  // bssid is a 17 character string
 		memcpy(&(reason.bssid), buf, 17); // Exclude null-termination
 	}
@@ -388,6 +391,7 @@ static void wifi_ap_sta_disassoc_hdl( char* buf, int buf_len, int flags, void* u
 	}
 
 	memset(&reason, 0, sizeof(rtk_reason_t));
+	reason.if_id = RTK_WIFI_SOFT_AP_IF;
 	if (strlen(buf) >= 17) { // bssid is a 17 character string
 		memcpy(&(reason.bssid), buf, 17);
 	}

--- a/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
+++ b/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
@@ -711,14 +711,7 @@ void cmd_wifi_info(int argc, char **argv)
 extern int netdev_ifrioctl(FAR struct socket *sock, int cmd, FAR struct ifreq *req);
 
 int8_t cmd_wifi_on(WiFi_InterFace_ID_t interface_id)
-{	if (interface_id>1){
-		lldbg("start concurrent");
-		wifi_on(3);
-		nvdbg("\r\n===============>>Finish wifi_on for concurrent!!\r\n");
-	return RTK_STATUS_SUCCESS;
-	}
-
-	lldbg("start sta");
+{
 	wifi_on(RTW_MODE_STA);
 
 	rtw_wifi_setting_t setting;


### PR DESCRIPTION
- Fix wifi events not being handled properly for bridge mode (trigger EVT_LEFT when STA received no beacon)
- Clean up unnecessary codes from previous bridge mode PR
Note:  Will be checking for any further changes to RTK layer, g_mode in rtk_netmgr.c may not be necessary